### PR TITLE
feat: add @electron scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,8 @@
     "@reach",
     "@jiakun-zhao",
     "@iyawoqu",
-    "@opentiny"
+    "@opentiny",
+    "@electron"
   ],
   "allowPackages": {
     "zhaojiakun.com": {


### PR DESCRIPTION
Since last year, the Electron team has been renaming its libraries, for example: `electron-asar` -> `@electron/asar`.

> electron remains unchanged (not exist `@electron/electron`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Electron framework to enhance desktop application capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->