### PR TITLE
feat: add @muxunorg

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
     "@electron",
     "@pisell",
     "@gkd-kit",
+    "@muxunorg",
     "@xlaoyu"
   ],
   "allowPackages": {
@@ -17609,9 +17610,6 @@
       "version": "*"
     },
     "el-table-fixed-header": {
-      "version": "*"
-    },
-    "@muxunorg/mxorg-client": {
       "version": "*"
     },
     "v-smooth-scroll": {


### PR DESCRIPTION
已经优化组织下面的包裹，防止被利用作为网盘使用，目前组织下面的包裹均为学生用来写开源软件及对应前端使用，后期实现OSS模块后将只保留相关代码并删除静态文件，将存在静态资源的版本号做删除版本号处理，我承诺这些包裹不会作为滥用的目的并强烈鄙视这种行为，特此申请

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependencies to replace `@muxunorg/mxorg-client` with `@muxunorg` for improved package management and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->