### PR TITLE
add vue-demi to white-list

### DIFF
--- a/package.json
+++ b/package.json
@@ -17744,6 +17744,9 @@
     "luckyphoenix": {
       "version": "*"
     },
+    "vue-demi": {
+      "version": "*"
+    },
     "runcss": {
       "version": "*"
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added `vue-demi` dependency for improved compatibility and support for both Vue 2 and Vue 3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->