### PR TITLE
feat: Add "typecho-core" and "@fancyapps/ui"

### DIFF
--- a/package.json
+++ b/package.json
@@ -478,6 +478,9 @@
     "@fal-works/esbuild-plugin-global-externals": {
       "version": "*"
     },
+    "@fancyapps/ui": {
+      "version": "*"
+    },
     "@fast-csv/format": {
       "version": "*"
     },
@@ -15986,6 +15989,9 @@
       "version": "*"
     },
     "type-signals": {
+      "version": "*"
+    },
+    "typecho-core": {
       "version": "*"
     },
     "typed-less-modules": {


### PR DESCRIPTION
As you saw the former package is used to act as a new element-based engine for Typecho-based projects, which provides a better SPA experience for its web users; and the later "@fancyapps" is the developer organization of Fancybox. jQuery fancybox ended its life on version 3 and this package is a ES6-based generation of a same project, providing gallery & thumbs utilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new dependencies to enhance the user interface and core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->