### PR TITLE
feat: add fc3 & 18x

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,6 +205,12 @@
     "@eslibs"
   ],
   "allowPackages": {
+    "fc3": {
+      "version": "*"
+    },
+    "18x": {
+      "version": "*"
+    },
     "alist-web": {
       "version": "*"
     },


### PR DESCRIPTION
https://www.npmjs.com/package/fc3
基于 cn-font-split 切分三种免费商用的中文字体，分包为300-500KB的小字体，以便于在网页上快速加载。


https://www.npmjs.com/package/18x

Util js for build web site

No need add npm package dependencies

Import directly in your js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for new packages `fc3` and `18x`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->