### PR TITLE
feat: add a modified aplayer

### DIFF
--- a/package.json
+++ b/package.json
@@ -17799,6 +17799,9 @@
     },
     "weblive2d": {
       "version": "*"
+    },
+    "loko-aper-mod": {
+      "version": "1.0.1"
     }
   }
 }


### PR DESCRIPTION
Source: https://www.npmjs.com/package/loko-aper-mod
该 aplayer mod 去除了在开启了 "lrcType" 后歌曲无歌词时会弹出报错信息的代码；仅需启用 1.0.1 版本

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added a new dependency `"loko-aper-mod"` version `"1.0.1"`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->