### PR TITLE
feat: add i18n.site

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,7 +209,8 @@
     "@ironkinoko",
     "@ikrong",
     "@eslibs",
-    "@itchenliang"
+    "@itchenliang",
+    "@i18n.site"
   ],
   "allowPackages": {
     "@itchenliang/picture-rollup-local-plugin": {
@@ -17892,6 +17893,12 @@
       "version": "*"
     },
     "9fit": {
+      "version": "*"
+    },
+    "18s": {
+      "version": "*"
+    },
+    "i18n.site": {
       "version": "*"
     }
   }


### PR DESCRIPTION
如图，我正在开发一个开源的markdown静态博客框架，用到的js
![image](https://github.com/cnpm/unpkg-white-list/assets/145643935/e63035d4-30ef-49be-8aaa-3a979af472d9)

代码还没正式发布，估计下个月发布，先提交一下方便调试

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated project collaborators to include `@i18n.site`.
  - Added `i18n.site` as a new dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->