### PR TITLE
feat: add `echarts-stat` and `echarts-graph-modularity`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4655,6 +4655,9 @@
     "echarts-nightly": {
       "version": "*"
     },
+    "echarts-stat": {
+      "version": "*"
+    },
     "echarts-wordcloud": {
       "version": "*"
     },


### PR DESCRIPTION
This is to add the missing packages [1] `echarts-stat`  and `echarts-graph-modularity` in the last PR #159. I'm sorry about that.

[1] https://echarts.apache.org/download-extension.html