### PR TITLE
feat: add `echarts-stat`, `echarts-graph-modularity` and `code-prettify` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4649,10 +4649,16 @@
     "echarts-gl": {
       "version": "*"
     },
+    "echarts-graph-modularity": {
+      "version": "*"
+    },
     "echarts-liquidfill": {
       "version": "*"
     },
     "echarts-nightly": {
+      "version": "*"
+    },
+    "echarts-stat": {
       "version": "*"
     },
     "echarts-wordcloud": {

--- a/package.json
+++ b/package.json
@@ -3311,6 +3311,9 @@
     "codemirror-solidity": {
       "version": "*"
     },
+    "code-prettify": {
+      "version": "*"
+    },
     "codql": {
       "version": "*"
     },


### PR DESCRIPTION
This is to add the missing packages [1] `echarts-stat`, `echarts-graph-modularity`, and `code-prettify` in the last PR #159. I'm sorry about that.

[1] https://echarts.apache.org/download-extension.html