### PR TITLE
feat: add pyodide

### DIFF
--- a/package.json
+++ b/package.json
@@ -18579,6 +18579,9 @@
     "speedtouch": {
       "version": "*"
     },
+    "pyodide": {
+      "version": "*"
+    },
     "@adonisjs/encryption": {
       "version": "*"
     },


### PR DESCRIPTION
pyodide : https://github.com/pyodide/pyodide

this package can run a python runtime in the browser : https://pyodide.org/en/stable/console.html

but the cost is the large file wasm size.