### PR TITLE
feat: add decap-cms

### DIFF
--- a/package.json
+++ b/package.json
@@ -4390,6 +4390,9 @@
     "decamelize": {
       "version": "*"
     },
+    "decap-cms": {
+      "version": "*"
+    },
     "decimal": {
       "version": "*"
     },


### PR DESCRIPTION
A CMS for static site generators. Give users a simple way to edit and add content to any site built with a static site generator.

Home page: https://decapcms.org/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package settings to allow the use of "decap-cms".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->