### PR TITLE
fix: remove @muxunorg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,7 @@ on:
 
 jobs:
   release:
-    name: Node.js
-    uses: cnpm/github-actions/.github/workflows/node-release.yml@master
+    name: NPM
+    uses: cnpm/github-actions/.github/workflows/npm-release.yml@master
     secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GIT_TOKEN: ${{ secrets.GIT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ _你将会看到 package.json 文件中的 `allowPackages` 字段被更新，如
 ### 添加指定 scope
 
 > [!WARNING]
-> scope 必须包含热门的包，如周下载量超过 1 万，新建的 scope 不允许添加，避免滥用。
+> 为避免滥用，申请添加的 scope 必须已包含热门包（如周下载量超过 1 万）。我们不接受为刚创建且无热门包的 scope 添加白名单。
 
 当然你发布的是 scoped package，可以用 CLI 添加 scope 到白名单 `allowScopes`：
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ _你将会看到 package.json 文件中的 `allowPackages` 字段被更新，如
 
 ### 添加指定 scope
 
+> [!WARN]
+> scope 必须包含热门的包，如周下载量超过 1 万，新建的 scope 不允许添加，避免滥用。
+
 当然你发布的是 scoped package，可以用 CLI 添加 scope 到白名单 `allowScopes`：
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ _你将会看到 package.json 文件中的 `allowPackages` 字段被更新，如
 
 ### 添加指定 scope
 
-> [!WARN]
+> [!WARNING]
 > scope 必须包含热门的包，如周下载量超过 1 万，新建的 scope 不允许添加，避免滥用。
 
 当然你发布的是 scoped package，可以用 CLI 添加 scope 到白名单 `allowScopes`：

--- a/package.json
+++ b/package.json
@@ -148,7 +148,6 @@
     "@microsoft",
     "@minecraft",
     "@miniu",
-    "@muxunorg",
     "@napi-rs",
     "@npmcli",
     "@nutui",


### PR DESCRIPTION
was added by https://github.com/cnpm/unpkg-white-list/pull/25

close https://github.com/cnpm/unpkg-white-list/issues/405

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a warning clarifying scope whitelisting: scopes must include popular packages (e.g., >10k weekly downloads); new scopes without popular packages won’t be accepted.

- Chores
  - Updated release automation to use an NPM-focused workflow and simplified secret requirements.
  - Tightened allowed scope policy by removing one previously permitted scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->