### PR TITLE
feat: add moefun to unpkg allow list

### DIFF
--- a/package.json
+++ b/package.json
@@ -10445,6 +10445,9 @@
     "modulex-querystring": {
       "version": "*"
     },
+    "moefun": {
+      "version": "*"
+    },
     "moment": {
       "version": "*"
     },


### PR DESCRIPTION
### Summary
Add the package `moefun` to the unpkg allow list to enable unpkg mirror support for **all versions**.

### Details
- Package: `moefun`
- Version range: `*` (all versions)
- Change scope: only `package.json` (`allowPackages.moefun.version = "*"`)
- Rationale: enable CDN/unpkg access via npmmirror to improve delivery and caching.

### Self-check
- [x] Only one file changed (`package.json`)
- [x] No formatting/noise changes
- [x] CI passed (Node.js setup & tests successful)

### Notes
Please help review and merge. Thanks!