### PR TITLE
feat: add aowubrowser to unpkg allow list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1904,6 +1904,9 @@
     "aos": {
       "version": "*"
     },
+    "aowubrowser": {
+      "version": "*"
+    },
     "ap-mini-ui": {
       "version": "*"
     },


### PR DESCRIPTION
### Summary
Add the package `aowubrowser` to the unpkg allow list to enable unpkg mirror support for **all versions**.

### Details
- Package: `aowubrowser`
- Version range: `*` (all versions)
- Change scope: only `package.json` (`allowPackages.aowubrowser.version = "*"`)

### Self-check
- [x] Only one file changed (`package.json`)
- [x] No formatting/noise changes
- [x] CI should pass (Node.js setup & tests)

### Notes
Please help review and merge. Thanks!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added the new allowed scope “aowubrowser” to project configuration, enabling recognition of packages under this scope by tooling and build processes.
  * Ensures compatibility for publishing and dependency resolution related to the new scope.
  * No runtime behavior changes and no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->