### PR TITLE
docs: add quotes requirement for CLI arguments with wildcards

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 用 CLI 添加你想开启 unpkg 文件同步的 npm 包名和版本号，全量同步版本号可以设置为 `*`，以同步 [urllib](https://npmmirror.com/package/urllib) 为示例：
 
 ```bash
-npm run add -- --pkg=urllib:* # 同步 urllib 所有版本
+npm run add -- "--pkg=urllib:*" # 同步 urllib 所有版本
 # or
 npm run add -- --pkg=urllib:1.0.0 # 同步 urllib 1.0.0 版本
 # or

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -9,25 +9,25 @@ const semverValidRange = require('semver/ranges/valid');
  * ### 添加一个新的包
  * 
  * ```bash
- * # npm run add --pkg={package name}:{version range}
- * npm run add --pkg=urllib:*
+ * # npm run add -- --pkg={package name}:{version range}
+ * npm run add -- "--pkg=urllib:*"
  * ```
  * ---
  * ### 添加一个新的 scope
  * 
  * ```bash
- * # npm run add --scope={scope name}
- * npm run add --scope=@ant-design
+ * # npm run add -- --scope={scope name}
+ * npm run add -- --scope=@ant-design
  * ```
  */
 const HELP = `
 Usage:
-  npm run add -- --package={package name}:{version range}
+  npm run add -- --pkg={package name}:{version range}
   npm run add -- --scope=@{scope name}
 
 Debug mode:
   Set DEBUG=true environment variable to use draft output and enable debug logging.
-  eg: DEBUG=true npm run add -- "--package=urllib:*"
+  eg: DEBUG=true npm run add -- "--pkg=urllib:*"
 `;
 
 const DEBUG = !!process.env.DEBUG


### PR DESCRIPTION
Clarify that arguments containing special characters like '*' must be quoted in zsh to prevent glob expansion errors.

Adding quotation marks to the default example makes it more user-friendly. 🙆‍♂️

```bash
# ✅
npm run add -- "--pkg=urllib:*"
npm run add -- '--pkg=lucide:*'
npm run add -- --pkg=lucide:\*

# ⚠️ zsh: no matches found
npm run add -- --pkg=lucide:*
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CLI usage examples and help text to show passing the flag after `--` and to wrap the `--pkg` argument in quotes for shell invocation.
* **Chores**
  * Updated displayed flag name to `--pkg` in examples and help output; no runtime behavior or parsing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->