### PR TITLE
feat: add ms-vue-elet@1.11.58 to allowLargePackages

### DIFF
--- a/package.json
+++ b/package.json
@@ -19001,6 +19001,9 @@
     },
     "wetrade-design": {
       "version": "*"
+    },
+    "ms-vue-elet": {
+      "version": "1.11.58"
     }
   },
   "blockSyncScopes": [


### PR DESCRIPTION
Allow syncing large tgz for ms-vue-elet to unblock npmmirror sync. I have already addressed the issue regarding the size of subsequent package volumes

## 添加白名单申请

请在提交此 Pull Request 之前，确认您已满足以下所有条件：

### ✅ 必须确认的条件

- [ ] **遵循添加说明**：我已经按照 [README.md](https://github.com/cnpm/unpkg-white-list/blob/master/README.md) 中的说明正确添加了白名单条目
- [ ] **包类型和使用情况**：我添加的 package 是 **library**（而不是 application），并且有真实的公网用户正在依赖使用。我们不接受为刚创建且没有真实下载流量的 package 添加白名单
- [ ] **Scope 要求**（如果申请添加 scope）：申请添加的 scope 必须已包含热门包（如周下载量超过 1 万）。我们不接受为刚创建且无热门包的 scope 添加白名单

### 📝 请提供以下信息

**添加的包/scope 名称：ms-vue-elet


**添加原因：目前1.11.58包体积过大，导致无法同步，后续1.11.59已优化体积大小，现在卡死在58同步不过去了


**使用情况说明（如周下载量、依赖该包的项目等）：**


### 📋 其他确认

- [ ] 我已使用 CLI 工具添加（推荐），或已确保手动修改的 `package.json` 格式正确
- [ ] 我理解此 PR 合并后会在 5 分钟内全网生效

---

感谢您为 unpkg 白名单做出贡献！🎉

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration to allow a new large package dependency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->