### PR TITLE
feat: add rolldown related packages to the whitelist

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,6 +195,7 @@
     "@remax",
     "@ricons",
     "@rjsf",
+    "@rolldown",
     "@rollup",
     "@ruiyun",
     "@rushstack",
@@ -14925,6 +14926,12 @@
     "rollbar": {
       "version": "*"
     },
+    "rolldown": {
+      "version": "*"
+    },
+    "rolldown-plugin-dts": {
+      "version": "*"
+    },
     "rollup": {
       "version": "*"
     },
@@ -16924,6 +16931,9 @@
       "version": "*"
     },
     "tsd": {
+      "version": "*"
+    },
+    "tsdown": {
       "version": "*"
     },
     "tsdx": {
@@ -18999,6 +19009,7 @@
     "@oven",
     "@pnpm",
     "@react-native-oh",
+    "@rolldown",
     "@rollup",
     "@shined",
     "@swc",
@@ -19177,6 +19188,9 @@
       "version": "*"
     },
     "react-icons": {
+      "version": "*"
+    },
+    "rolldown": {
       "version": "*"
     },
     "rx-compo": {


### PR DESCRIPTION
## 添加白名单申请

请在提交此 Pull Request 之前，确认您已满足以下所有条件：

### ✅ 必须确认的条件

- [x] **遵循添加说明**：我已经按照 [README.md](https://github.com/cnpm/unpkg-white-list/blob/master/README.md) 中的说明正确添加了白名单条目
- [x] **非 GKD 订阅规则**：我添加的包 **不是** GKD 广告屏蔽订阅规则相关的包（包含 `gkd`、`gkd-subscription`、`gkd_subscription` 等关键词的包将被直接关闭）
- [x] **包类型和使用情况**：我添加的 package 是 **library**（而不是 application），并且有真实的公网用户正在依赖使用。我们不接受为刚创建且没有真实下载流量的 package 添加白名单
- [x] **Scope 要求**（如果申请添加 scope）：申请添加的 scope 必须已包含热门包（如周下载量超过 1 万）。我们不接受为刚创建且无热门包的 scope 添加白名单

### 📝 请提供以下信息

**添加的包/scope 名称：**
- 添加 `rolldown-plugin-dts` 到 allowPackages
- 添加 `rolldown` 到 allowPackages 与 allowLargePackages
- 添加  `@rolldown` 到 allowScopes 与 allowLargeScopes
- 添加 `tsdown` 到 allowPackages

**添加原因：**

[rolldown](https://rolldown.rs/) 是 `Fast Rust-based bundler for JavaScript with Rollup-compatible API`，是下一代 Vite 生产构建核心，生态影响力大、使用广泛，且已在 [Vite 8](https://vite.dev/) 中成为默认打包器（[来源](https://vite.dev/blog/announcing-vite8.html)），需要加入 unpkg 白名单以保证正常分发与访问。项目位于：https://github.com/rolldown/rolldown

一并添加了相关生态中的包以便使用：

[@rolldown](https://www.npmjs.com/search?q=%40rolldown) 中主要包含：
- [rolldown 的 Rust 代码编译后的 .node 二进制文件](https://www.npmjs.com/search?q=%40rolldown%2Fbinding-)，如 [@rolldown/binding-linux-x64-gnu](https://www.npmjs.com/package/@rolldown/binding-linux-x64-gnu)，**rolldown 运行时需要这些文件**；
- 一些与 rolldown 相关的插件，如 [@rolldown/plugin-babel](https://www.npmjs.com/package/@rolldown/plugin-babel)；

[rolldown-plugin-dts](https://www.npmjs.com/package/rolldown-plugin-dts) 是 rolldown 团队开发的 TypeScript d.ts 插件，用于生成 d.ts 类型定义文件以便 TypeScript 使用，项目位于 https://github.com/sxzz/rolldown-plugin-dts；

[tsdown](https://github.com/rolldown/tsdown) 是由 rolldown 团队开发的 `The elegant bundler for libraries`，用于构建 TypeScript 库，项目位于 https://github.com/rolldown/tsdown；

**使用情况说明（如周下载量、依赖该包的项目等）：**

周下载量 (下列数据均统计到 2026-04-01~2026-04-07，数据源：npmjs.com)：
- [rolldown](https://www.npmjs.com/package/rolldown): 17224034; 被大量项目依赖，如 [vite 8.0.7](https://www.npmjs.com/package/vite/v/8.0.7?activeTab=dependencies) 等;
- @rolldown: 包含许多下载量高的包，如 [@rolldown/binding-linux-x64-gnu](https://www.npmjs.com/package/@rolldown/binding-linux-x64-gnu) 下载量 14541604 ，[@rolldown/binding-win32-x64-msvc](https://www.npmjs.com/package/@rolldown/binding-win32-x64-msvc) 下载量 1777665;
- [rolldown-plugin-dts](https://www.npmjs.com/package/rolldown-plugin-dts): 1501645;
- [tsdown](https://www.npmjs.com/package/tsdown): 1387671;

### 📋 其他确认

- [x] 我已使用 CLI 工具添加（推荐），或已确保手动修改的 `package.json` 格式正确
- [x] 我理解此 PR 合并后会在 5 分钟内全网生效


---

感谢您为 unpkg 白名单做出贡献！🎉


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build toolchain configuration to support the rolldown bundler and related dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->