### PR TITLE
feat: add werewolf-judge-cdn to allowPackages

### DIFF
--- a/package.json
+++ b/package.json
@@ -18508,6 +18508,9 @@
     "wellknown": {
       "version": "*"
     },
+    "werewolf-judge-cdn": {
+      "version": "*"
+    },
     "westore": {
       "version": "*"
     },


### PR DESCRIPTION
## 添加白名单申请

### ✅ 必须确认的条件

- [x] **遵循添加说明**：我已经按照 [README.md](https://github.com/cnpm/unpkg-white-list/blob/master/README.md) 中的说明正确添加了白名单条目
- [x] **非 GKD 订阅规则**：我添加的包 **不是** GKD 广告屏蔽订阅规则相关的包（包含 `gkd`、`gkd-subscription`、`gkd_subscription` 等关键词的包将被直接关闭）
- [x] **包类型和使用情况**：我添加的 package 是 **library**（而不是 application），并且有真实的公网用户正在依赖使用。我们不接受为刚创建且没有真实下载流量的 package 添加白名单
- [ ] **Scope 要求**（如果申请添加 scope）：申请添加的 scope 必须已包含热门包（如周下载量超过 1 万）。我们不接受为刚创建且无热门包的 scope 添加白名单

### 📝 请提供以下信息

**添加的包/scope 名称：**

[werewolf-judge-cdn](https://www.npmjs.com/package/werewolf-judge-cdn)

**添加原因：**

`werewolf-judge-cdn` 是一个 JS 工具库，导出 [WerewolfGameJudge](https://github.com/olveryu/WerewolfGameJudge)（React Native / Expo web 应用）的资源清单（`index.js` 导出 `{ version, assets }`），供部署脚本和 Service Worker 在运行时消费，用于缓存策略和版本管理。

**使用情况说明（如周下载量、依赖该包的项目等）：**

该包被 WerewolfGameJudge 项目的 CI/CD pipeline 和 Service Worker 直接依赖。每次部署自动 publish 新版本，线上用户通过该包的资源清单进行 JS bundle 版本校验和缓存更新。

### 📋 其他确认

- [x] 我已使用 CLI 工具添加（推荐），或已确保手动修改的 `package.json` 格式正确
- [x] 我理解此 PR 合并后会在 5 分钟内全网生效