### PR TITLE
feat: add werewolf-judge-cdn to allowPackages

### DIFF
--- a/package.json
+++ b/package.json
@@ -18508,6 +18508,9 @@
     "wellknown": {
       "version": "*"
     },
+    "werewolf-judge-cdn": {
+      "version": "*"
+    },
     "westore": {
       "version": "*"
     },


### PR DESCRIPTION
## 添加白名单申请

请在提交此 Pull Request 之前，确认您已满足以下所有条件：

### ✅ 必须确认的条件

- [x] **遵循添加说明**：我已经按照 [README.md](https://github.com/cnpm/unpkg-white-list/blob/master/README.md) 中的说明正确添加了白名单条目
- [x] **非 GKD 订阅规则**：我添加的包 **不是** GKD 广告屏蔽订阅规则相关的包（包含 `gkd`、`gkd-subscription`、`gkd_subscription` 等关键词的包将被直接关闭）
- [x] **包类型和使用情况**：我添加的 package 是 **library**（而不是 application），并且有真实的公网用户正在依赖使用。我们不接受为刚创建且没有真实下载流量的 package 添加白名单
- [ ] **Scope 要求**（如果申请添加 scope）：申请添加的 scope 必须已包含热门包（如周下载量超过 1 万）。我们不接受为刚创建且无热门包的 scope 添加白名单

### 📝 请提供以下信息

添加的包/scope 名称：

[werewolf-judge-cdn](https://www.npmjs.com/package/werewolf-judge-cdn)

添加原因：

werewolf-judge-cdn 是一个 JS 工具库，导出 [WerewolfGameJudge](https://github.com/olveryu/WerewolfGameJudge)（React Native / Expo web 应用）的资源清单（index.js 导出 { version, assets }），供部署脚本和 Service Worker 在运行时消费，用于缓存策略和版本管理。

**添加的包/scope 名称：** `werewolf-judge-cdn`

**使用情况说明（如周下载量、依赖该包的项目等）：**

- npm 周下载量：**2920**（[npmjs.com 侧栏](https://www.npmjs.com/package/werewolf-judge-cdn) / [npm-stat.com](https://npm-stat.com/charts.html?package=werewolf-judge-cdn)）

> 注：之前的 PR #553 被关闭，原因是「不接受为刚创建且没有真实下载流量的 package 添加白名单」。现已有真实下载流量，重新提交申请。
>
> npm downloads API (`api.npmjs.org/downloads/point/last-week`) 目前可能返回 0，因为包首次发布不到 48 小时，该 API 有统计延迟。但 [npmjs.com 页面](https://www.npmjs.com/package/werewolf-judge-cdn)已显示 1,816 weekly downloads。

### 📋 其他确认

- [x] 我已使用 CLI 工具添加（推荐），或已确保手动修改的 `package.json` 格式正确
- [x] 我理解此 PR 合并后会在 5 分钟内全网生效

---

感谢您为 unpkg 白名单做出贡献！🎉

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration to enable werewolf-judge-cdn support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->