### PR TITLE
feat: add `@quasar/extras` to allowLargePackages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "unpkg-white-list",
-  "version": "1.291.1",
-  "description": "npmmirror \u5141\u8bb8\u5f00\u542f unpkg \u548c sync package tgz \u8d85\u5927\u6587\u4ef6\u529f\u80fd\u7684\u767d\u540d\u5355\u5217\u8868",
+  "version": "1.291.0",
+  "description": "npmmirror 允许开启 unpkg 和 sync package tgz 超大文件功能的白名单列表",
   "main": "index.js",
   "files": [],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "unpkg-white-list",
-  "version": "1.291.0",
-  "description": "npmmirror 允许开启 unpkg 和 sync package tgz 超大文件功能的白名单列表",
+  "version": "1.291.1",
+  "description": "npmmirror \u5141\u8bb8\u5f00\u542f unpkg \u548c sync package tgz \u8d85\u5927\u6587\u4ef6\u529f\u80fd\u7684\u767d\u540d\u5355\u5217\u8868",
   "main": "index.js",
   "files": [],
   "scripts": {
@@ -19057,6 +19057,9 @@
       "version": "*"
     },
     "@qingchencloud/openclaw-zh": {
+      "version": "*"
+    },
+    "@quasar/extras": {
       "version": "*"
     },
     "@tntd/dll": {


### PR DESCRIPTION
Add `@quasar/extras` to `allowLargePackages` to allow syncing versions larger than 80MB.

`@quasar/extras@1.18.0` package size is 86664663 bytes, which exceeds the default 83886080 bytes limit.

Related error from npmmirror sync log:
```
Synced version 1.18.0 skipped, large package version size: 86664663, allow size: 83886080
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released version 1.292.0.
  * Updated configuration to permit the quasar extras package as a large-package, allowing its use without size restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->