### PR TITLE
feat(whitelist): allow large sync for @teamolab/teamo-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -19068,6 +19068,9 @@
     "@quasar/extras": {
       "version": "*"
     },
+    "@teamolab/teamo-cli": {
+      "version": ">=0.1.2 <0.1.8"
+    },
     "@tntd/dll": {
       "version": "*"
     },

--- a/package.json
+++ b/package.json
@@ -19069,7 +19069,7 @@
       "version": "*"
     },
     "@teamolab/teamo-cli": {
-      "version": "*"
+      "version": ">=0.1.2 <0.1.8"
     },
     "@tntd/dll": {
       "version": "*"

--- a/package.json
+++ b/package.json
@@ -19069,7 +19069,7 @@
       "version": "*"
     },
     "@teamolab/teamo-cli": {
-      "version": ">=0.1.2 <0.1.8"
+      "version": "*"
     },
     "@tntd/dll": {
       "version": "*"


### PR DESCRIPTION
Add `@teamolab/teamo-cli` to `allowLargePackages` with version range `>=0.1.2 <0.1.8`.

Reason:
- versions `0.1.2` to `0.1.7` are the six affected releases
- these versions are abnormally large and fit the large tgz sync whitelist path
- `0.1.8+` is already back to normal package size, so the range stays narrow