### PR TITLE
feat(whitelist): allow large sync for @teamolab/teamo-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -19068,6 +19068,9 @@
     "@quasar/extras": {
       "version": "*"
     },
+    "@teamolab/teamo-cli": {
+      "version": "*"
+    },
     "@tntd/dll": {
       "version": "*"
     },


### PR DESCRIPTION
Add `@teamolab/teamo-cli` to `allowLargePackages` with `*`.

This keeps the entry generated in alphabetical order and enables the large package sync whitelist for the package.