### PR TITLE
feat: allow binaryen in large package whitelist

### DIFF
--- a/data/allowLargePackages.json
+++ b/data/allowLargePackages.json
@@ -44,6 +44,9 @@
   "aws-cdk-lib": {
     "version": "*"
   },
+  "binaryen": {
+    "version": "*"
+  },
   "cline": {
     "version": "*"
   },


### PR DESCRIPTION
## 背景
在升级 `assemblyscript` 到最新 `v0.28.17` 时，其依赖的 `binaryen` 从 `v123` 升级到 `v129`。

由于我们的安装链路为：阿里云私有 npm -> cnpm -> 公共 npm，且 cnpm 对大包同步有白名单限制（用于避免被灰产当作网盘滥用），当前 `binaryen` 未在大包白名单中会导致同步受限。

## 变更
- 在 `data/allowLargePackages.json` 中新增：
  - `binaryen`: `*`

## 验证
- `npm run lint`
- `npm test`

以上命令在本地均已通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package support configuration to allow larger packages, including `binaryen`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->