### PR TITLE
fix: drop postpack so registry packument keeps the merged lists

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "test": "node --test",
     "ci": "npm test",
     "add": "node scripts/generate.js",
-    "prepack": "node scripts/build-pkg.js merge",
-    "postpack": "node scripts/build-pkg.js restore"
+    "prepack": "node scripts/build-pkg.js merge"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.2.0",

--- a/scripts/build-pkg.js
+++ b/scripts/build-pkg.js
@@ -27,8 +27,10 @@ function writeJson(file, value) {
 
 function merge() {
   const original = fs.readFileSync(PKG_PATH, 'utf-8');
-  // If a prior prepack crashed before postpack ran, package.json is already
-  // merged and .bak holds the true source — keep .bak immutable until restore.
+  // npm publish re-reads package.json AFTER pack() runs to build the
+  // registry manifest, so prepack must leave the merged lists in place — no
+  // postpack restore. .bak preserves the original for manual `restore` use
+  // (local `npm pack` workflow); keep it immutable on re-merge.
   try {
     fs.writeFileSync(BAK_PATH, original, { flag: 'wx' });
   } catch (err) {

--- a/test/index.js
+++ b/test/index.js
@@ -1,11 +1,13 @@
 const test = require('node:test');
 const { strict: assert } = require('node:assert');
-const { readFileSync, writeFileSync } = require('node:fs');
+const { execSync } = require('node:child_process');
+const { existsSync, readFileSync, unlinkSync, writeFileSync } = require('node:fs');
 const { dirname, join } = require('node:path');
 const semverValidRange = require('semver/ranges/valid');
 
 const ROOT = dirname(__dirname);
 const pkgFile = join(ROOT, 'package.json');
+const bakFile = join(ROOT, 'package.json.bak');
 const dataDir = join(ROOT, 'data');
 
 function readAndNormalize(file) {
@@ -180,6 +182,38 @@ test('should pkg.blockSyncPackages work', () => {
   console.log('Total %d block sync packages', packages);
   assert(packages > 0);
   assert(blockSyncPackages.length === packages, 'blockSyncPackages length should be equal to packages length');
+});
+
+// Regression test for the registry-packument bug introduced by #565.
+// `npm publish` re-reads package.json AFTER `pack()` (i.e. after postpack)
+// to build the manifest it uploads to the registry. If postpack restores
+// an unmerged package.json, the registry packument loses allowPackages etc.
+// (see https://registry.npmjs.com/unpkg-white-list/1.299.0).
+test('npm pack must leave package.json with merged lists for the registry manifest', () => {
+  const savedPkg = readFileSync(pkgFile, 'utf-8');
+  const savedBak = existsSync(bakFile) ? readFileSync(bakFile) : null;
+  try {
+    execSync('npm pack --dry-run --silent', { cwd: ROOT, stdio: 'pipe' });
+    const afterPack = JSON.parse(readFileSync(pkgFile, 'utf-8'));
+    for (const field of [
+      'allowScopes',
+      'allowPackages',
+      'allowLargeScopes',
+      'allowLargePackages',
+      'blockSyncScopes',
+      'blockSyncPackages',
+    ]) {
+      assert(afterPack[field], `package.json after pack must have ${field} — npm publish re-reads it after pack to build the registry manifest`);
+    }
+    assert(Object.keys(afterPack.allowPackages).length > 0, 'allowPackages must not be empty');
+  } finally {
+    writeFileSync(pkgFile, savedPkg);
+    if (savedBak === null) {
+      if (existsSync(bakFile)) unlinkSync(bakFile);
+    } else {
+      writeFileSync(bakFile, savedBak);
+    }
+  }
 });
 
 test('check blockSyncPackages and blockSyncScopes', () => {


### PR DESCRIPTION
## Summary

The published [1.299.0 packument](https://registry.npmjs.com/unpkg-white-list/1.299.0) is missing `allowPackages`, `allowScopes`, `allowLargePackages`, `allowLargeScopes`, `blockSyncPackages`, and `blockSyncScopes`. The 1.298.0 packument (and earlier) had them. The tarball is fine — only the registry packument lost the fields. This regression was introduced by #565.

## Root cause

`npm publish` reads `package.json` to build the registry manifest **twice** — once before `pack()` runs and again after it returns. From [`npm/cli/lib/commands/publish.js`](https://github.com/npm/cli/blob/latest/lib/commands/publish.js):

```js
let manifest = await this.#getManifest(spec, opts)
const tarballData = await pack(spec, { ...opts, dryRun: true, ... })
manifest = await this.#getManifest(spec, opts, true)
// "in case it changed, so that we send the latest and greatest thing
//  to the registry note that publishConfig might have changed as well!"
```

`pack()` runs `prepack` (merge) → builds tarball → runs `postpack` (restore). After `postpack`, `package.json` is back to the unmerged source, and that's what the second `getManifest` reads. So the registry packument never sees the lists.

The release log from [run 25483706742](https://github.com/cnpm/unpkg-white-list/actions/runs/25483706742/job/74773858369) confirms this — `prepack` and `postpack` both ran successfully, the tarball has all six fields (verified locally: 6236 `allowPackages`, 258 `allowScopes`, 70 `allowLargePackages`, …), but the registry-side metadata is missing them.

## Fix

Drop the `postpack` script so the merged `package.json` survives into the second manifest read. The `restore` command stays as a manual utility for the local `npm pack` workflow (devs can also just `git checkout package.json`).

## Test plan

- [x] New regression test in `test/index.js` runs `npm pack --dry-run` and asserts that all six list fields are present in `package.json` afterwards. Fails on `master`, passes on this branch.
- [x] `npm test` — 10/10 pass
- [x] `npm run lint` — clean
- [ ] Verify the next release on this branch produces a packument that contains the six fields (i.e. the next version of the JSON at `https://registry.npmjs.com/unpkg-white-list/<version>` has `allowPackages`, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automatic post-packaging script execution.

* **Tests**
  * Added regression test to verify dry-run packaging behavior preserves package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->