### PR TITLE
feat: add happy to allowLargePackages

### DIFF
--- a/data/allowLargePackages.json
+++ b/data/allowLargePackages.json
@@ -74,6 +74,9 @@
   "gsd-pi": {
     "version": "*"
   },
+  "happy": {
+    "version": "*"
+  },
   "hdw2": {
     "version": "*"
   },

--- a/data/allowPackages.json
+++ b/data/allowPackages.json
@@ -7031,6 +7031,9 @@
   "hapi": {
     "version": "*"
   },
+  "happy": {
+    "version": "*"
+  },
   "happy-dom": {
     "version": "*"
   },

--- a/data/allowPackages.json
+++ b/data/allowPackages.json
@@ -7031,9 +7031,6 @@
   "hapi": {
     "version": "*"
   },
-  "happy": {
-    "version": "*"
-  },
   "happy-dom": {
     "version": "*"
   },


### PR DESCRIPTION
Currently happy is pointed to a different package and sync will failed.

# ⚠️注意：我不清楚我的修改是否可以实际解决问题，请务必核查后再合入！！

关联：

- https://github.com/slopus/happy/issues/1153

## 添加白名单申请

请在提交此 Pull Request 之前，确认您已满足以下所有条件：

### ✅ 必须确认的条件

- [x] **遵循添加说明**：我已经按照 [README.md](https://github.com/cnpm/unpkg-white-list/blob/master/README.md) 中的说明正确添加了白名单条目
- [x] **非 GKD 订阅规则**：我添加的包 **不是** GKD 广告屏蔽订阅规则相关的包（包含 `gkd`、`gkd-subscription`、`gkd_subscription` 等关键词的包将被直接关闭）
- [ ] **包类型和使用情况**：我添加的 package 是 **library**（而不是 application），并且有真实的公网用户正在依赖使用。我们不接受为刚创建且没有真实下载流量的 package 添加白名单
- [ ] **Scope 要求**（如果申请添加 scope）：申请添加的 scope 必须已包含热门包（如周下载量超过 1 万）。我们不接受为刚创建且无热门包的 scope 添加白名单

### 📝 请提供以下信息

**添加的包/scope 名称：**

happy

**添加原因：**

当前 npmmirror 的 happy 指向了完全不同的包，尝试同步会失败。此 PR 旨在希望同步成功以使得 npmmirror 可以通过 happy 名称安装到和上游原始 npm 仓库相同的包。

**使用情况说明（如周下载量、依赖该包的项目等）：**


### 📋 其他确认

- [x] 我已使用 CLI 工具添加（推荐），或已确保手动修改的 `package.json` 格式正确
- [x] 我理解此 PR 合并后会在 5 分钟内全网生效

---

感谢您为 unpkg 白名单做出贡献！🎉


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an additional package with large package handling capabilities enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->