### PR TITLE
feat: add `@code-yeongyu/comment-checker` to allowLargePackages

### DIFF
--- a/data/allowLargePackages.json
+++ b/data/allowLargePackages.json
@@ -8,6 +8,9 @@
   "@codeblitzjs/ide-core": {
     "version": "*"
   },
+  "@code-yeongyu/comment-checker": {
+    "version": "*"
+  }
   "@comate/zulu": {
     "version": "*"
   },

--- a/data/allowLargePackages.json
+++ b/data/allowLargePackages.json
@@ -5,12 +5,12 @@
   "@belife/belife-bim-air": {
     "version": "*"
   },
+  "@code-yeongyu/comment-checker": {
+    "version": "*"
+  },
   "@codeblitzjs/ide-core": {
     "version": "*"
   },
-  "@code-yeongyu/comment-checker": {
-    "version": "*"
-  }
   "@comate/zulu": {
     "version": "*"
   },


### PR DESCRIPTION
## 添加白名单申请

请在提交此 Pull Request 之前，确认您已满足以下所有条件：

### ✅ 必须确认的条件

- [x] **遵循添加说明**：我已经按照 [README.md](https://github.com/cnpm/unpkg-white-list/blob/master/README.md) 中的说明正确添加了白名单条目
- [x] **非 GKD 订阅规则**：我添加的包 **不是** GKD 广告屏蔽订阅规则相关的包（包含 `gkd`、`gkd-subscription`、`gkd_subscription` 等关键词的包将被直接关闭）
- [x] **包类型和使用情况**：我添加的 package 是 **library**（而不是 application），并且有真实的公网用户正在依赖使用。我们不接受为刚创建且没有真实下载流量的 package 添加白名单
- [x] **Scope 要求**（如果申请添加 scope）：申请添加的 scope 必须已包含热门包（如周下载量超过 1 万）。我们不接受为刚创建且无热门包的 scope 添加白名单

### 📝 请提供以下信息

**添加的包/scope 名称：**

@code-yeongyu/comment-checker

**添加原因：**

`@code-yeongyu/comment-checker` 是一个基于 Go 语言构建的 Claude Code 代码审查工具，提供原生二进制文件。自 0.7.1 版本起，由于 Go 二进制文件的体积特性，其 npm 包大小达到了约 218 MB（217,894,370 字节），超过了 npmmirror 镜像站默认的 80 MB（83,886,080 字节）同步上限，导致同步失败并被镜像站放弃。

npmmirror 同步日志显示如下错误：
```
upstream error: large package version size: 217894370, allow size: 83886080,
see https://github.com/cnpm/unpkg-white-list, white list version: 1.306.0
Sync @code-yeongyu/comment-checker fail … 🚮 give up 🚮
```

这意味着使用 npmmirror 镜像源的中国开发者无法获取该包的 0.7.1 及以上任何新版本（当前最新为 0.8.0），从而导致依赖此包的下游项目（如 `oh-my-openagent`）无法正常安装和运行。


**使用情况说明（如周下载量、依赖该包的项目等）：**

周下载量
<img width="2252" height="1370" alt="image" src="https://github.com/user-attachments/assets/d944f23d-4245-4a8e-9d9c-5fbbf79679fb" />

影响下游oh-my-openagent(opencode生态最火的插件)的安装和启动

### 📋 其他确认

- [x] 我已使用 CLI 工具添加（推荐），或已确保手动修改的 `package.json` 格式正确
- [x] 我理解此 PR 合并后会在 5 分钟内全网生效


---

感谢您为 unpkg 白名单做出贡献！🎉


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package allowlist configuration to support additional packages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cnpm/unpkg-white-list/pull/580?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->