### PR TITLE
feat(allowLargePackages): add expo-image

### DIFF
--- a/data/allowLargePackages.json
+++ b/data/allowLargePackages.json
@@ -74,6 +74,9 @@
   "element-ai-vue": {
     "version": "*"
   },
+  "expo-image": {
+    "version": "*"
+  },
   "ggk-happy": {
     "version": "*"
   },


### PR DESCRIPTION
## 添加白名单申请

请在提交此 Pull Request 之前，确认您已满足以下所有条件：

### ✅ 必须确认的条件

- [x] **遵循添加说明**：我已经按照 [README.md](https://github.com/cnpm/unpkg-white-list/blob/master/README.md) 中的说明正确添加了白名单条目
- [x] **非 GKD 订阅规则**：我添加的包 **不是** GKD 广告屏蔽订阅规则相关的包（包含 `gkd`、`gkd-subscription`、`gkd_subscription` 等关键词的包将被直接关闭）
- [x] **包类型和使用情况**：我添加的 package 是 **library**（而不是 application），并且有真实的公网用户正在依赖使用。我们不接受为刚创建且没有真实下载流量的 package 添加白名单
- [x] **Scope 要求**（如果申请添加 scope）：申请添加的 scope 必须已包含热门包（如周下载量超过 1 万）。我们不接受为刚创建且无热门包的 scope 添加白名单

### 📝 请提供以下信息

**添加的包/scope 名称：**

`expo-image`（添加到 `data/allowLargePackages.json`，即 sync package tgz 超大文件白名单）

**添加原因：**

`expo-image` 的 tarball 体积超过 80MB 上限（如 `56.0.7` 约 135MB），导致从上游 `r.cnpmjs.org` 同步失败，错误信息：

```
Synced version 56.0.7 fail, too many large versions (4),
large package version size: 135936965, allow size: 83886080
```

由于同步失败，`expo-image@~56.0.9` 等较新版本在 cdn.npmmirror.com 上不可用，导致 `npm i` 报 `ETARGET / No matching version found for expo-image@~56.0.9`。加入 `allowLargePackages` 白名单可放开大体积 tarball 的同步限制。

**使用情况说明（如周下载量、依赖该包的项目等）：**

`expo-image` 是 [Expo](https://expo.dev) 官方维护的 React Native 高性能图片组件，基于 [SDWebImage](https://github.com/SDWebImage/SDWebImage)（iOS）与 [Glide](https://github.com/bumptech/glide)（Android）实现，相比 RN 内置的 `Image` 组件提供更好的内存管理、缓存策略与动画支持。该包是 Expo SDK 的组成部分，被 Expo 官方推荐为默认图片组件，被海量 React Native / Expo 项目依赖使用。

### 📋 其他确认

- [x] 我已使用 CLI 工具添加（推荐），或已确保手动修改的 `package.json` 格式正确
- [x] 我理解此 PR 合并后会在 5 分钟内全网生效


---

感谢您为 unpkg 白名单做出贡献！🎉