### PR TITLE
feat: add makecoder-bin packages to allowLargePackages

### DIFF
--- a/data/allowLargePackages.json
+++ b/data/allowLargePackages.json
@@ -101,13 +101,13 @@
   "makecoder": {
     "version": "*"
   },
-  "makecoder-codex-darwin-arm64": {
+  "makecoder-bin-darwin-arm64": {
     "version": "*"
   },
-  "makecoder-codex-linux-x64": {
+  "makecoder-bin-linux-arm64": {
     "version": "*"
   },
-  "makecoder-codex-win32-x64": {
+  "makecoder-bin-linux-x64": {
     "version": "*"
   },
   "minecraft-data": {


### PR DESCRIPTION
…coder-bin packages

Remove makecoder-codex-darwin-arm64, makecoder-codex-linux-x64, makecoder-codex-win32-x64 and add makecoder-bin-darwin-arm64, makecoder-bin-linux-x64, makecoder-bin-linux-arm64.

## 添加白名单申请

请在提交此 Pull Request 之前，确认您已满足以下所有条件：

### ✅ 必须确认的条件

- [x] **遵循添加说明**：我已经按照 [README.md](https://github.com/cnpm/unpkg-white-list/blob/master/README.md) 中的说明正确添加了白名单条目
- [x] **非 GKD 订阅规则**：我添加的包 **不是** GKD 广告屏蔽订阅规则相关的包（包含 `gkd`、`gkd-subscription`、`gkd_subscription` 等关键词的包将被直接关闭）
- [x] **包类型和使用情况**：我添加的 package 是 **library**（而不是 application），并且有真实的公网用户正在依赖使用。我们不接受为刚创建且没有真实下载流量的 package 添加白名单
- [x] **Scope 要求**（如果申请添加 scope）：申请添加的 scope 必须已包含热门包（如周下载量超过 1 万）。我们不接受为刚创建且无热门包的 scope 添加白名单

### 📝 请提供以下信息

**添加的包/scope 名称：**
  makecoder-bin-darwin-arm64, makecoder-bin-linux-x64, makecoder-bin-linux-arm64

**添加原因：**
  Replace deprecated makecoder-codex-* binary packages with the new makecoder-bin-* naming.

**使用情况说明（如周下载量、依赖该包的项目等）：**
 MakeCoder IDE platform-specific binary packages. Replaces makecoder-codex-darwin-arm64, makecoder-codex-linux-x64, makecoder-codex-win32-x64 which are being deprecated.

### 📋 其他确认

- [x] 我已使用 CLI 工具添加（推荐），或已确保手动修改的 `package.json` 格式正确
- [x] 我理解此 PR 合并后会在 5 分钟内全网生效


---

感谢您为 unpkg 白名单做出贡献！🎉


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated makecoder package configuration to improve platform support. Removed certain package types and introduced binary packages for Darwin ARM64, Linux ARM64, and Linux x64 platforms, enhancing compatibility across additional system architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->