### PR TITLE
feat: add @mcp-b/webmcp-local-relay to allowPackages

### DIFF
--- a/data/allowPackages.json
+++ b/data/allowPackages.json
@@ -572,6 +572,9 @@
   "@matejmazur/react-katex": {
     "version": "*"
   },
+  "@mcp-b/webmcp-local-relay": {
+    "version": "*"
+  },
   "@mdi/font": {
     "version": "*"
   },


### PR DESCRIPTION
Add `@mcp-b/webmcp-local-relay` to allowPackages so that its files can be served via npmmirror unpkg.

This package provides an embed script for MCP local relay functionality, and downstream users need to load it via:
```
https://registry.npmmirror.com/@mcp-b/webmcp-local-relay/latest/files/dist/browser/embed.js
```

See: https://www.npmjs.com/package/@mcp-b/webmcp-local-relay

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package allowlist to include `@mcp-b/webmcp-local-relay`, allowing it to be recognized as permitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->