### PR TITLE
feat: add `@file-viewer` to allowScopes

### DIFF
--- a/data/allowScopes.json
+++ b/data/allowScopes.json
@@ -54,6 +54,7 @@
   "@fesjs",
   "@ffmpeg",
   "@figma",
+  "@file-viewer",
   "@floating-ui",
   "@floatsheep",
   "@fluentui",


### PR DESCRIPTION
Add `@file-viewer` scope to npmmirror unpkg allowScopes whitelist.

This enables unpkg file access for packages published under the `@file-viewer` scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional allowed scope, expanding available access options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->