### PR TITLE
feat: add `@file-viewer` to allowLargeScopes

### DIFF
--- a/data/allowLargeScopes.json
+++ b/data/allowLargeScopes.json
@@ -7,6 +7,7 @@
   "@deno",
   "@desirecore",
   "@duckdb",
+  "@file-viewer",
   "@fonixtree",
   "@github",
   "@glyphix",


### PR DESCRIPTION
## 背景

`@file-viewer` 部分版本 tgz 超过默认 80MB 同步限制，导致 npmmirror 同步失败：

```
Synced version 2.1.12 fail, too many large versions (4), large package version size: 116066399, allow size: 83886080
```

此前 PR #602 仅将 `@file-viewer` 加入 `allowScopes`（unpkg 白名单），无法解决 **超大文件 tgz 同步** 问题。

## 变更

将 `@file-viewer` 加入 `data/allowLargeScopes.json`，允许该 scope 下大包版本同步。

## 参考

- [unpkg-white-list README - allowLargeScopes](https://github.com/cnpm/unpkg-white-list#sync-package-tgz-超大文件白名单添加指定-scope)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded support to include the `@file-viewer` scope in the allowed large-scope list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->