### PR TITLE
feat: add hermes-web-ui to allowLargePackages

### DIFF
--- a/data/allowLargePackages.json
+++ b/data/allowLargePackages.json
@@ -95,6 +95,9 @@
   "heren-design-web-vue": {
     "version": "*"
   },
+  "hermes-web-ui": {
+    "version": "*"
+  },
   "koffi": {
     "version": "*"
   },


### PR DESCRIPTION

## 添加白名单申请

请在提交此 Pull Request 之前，确认您已满足以下所有条件：

### ✅ 必须确认的条件

- [x] **遵循添加说明**：我已经按照 [README.md](https://github.com/cnpm/unpkg-white-list/blob/master/README.md) 中的说明正确添加了白名单条目
- [x] **非 GKD 订阅规则**：我添加的包 **不是** GKD 广告屏蔽订阅规则相关的包（包含 `gkd`、`gkd-subscription`、`gkd_subscription` 等关键词的包将被直接关闭）
- [x] **包类型和使用情况**：我添加的 package 是 **library**（而不是 application），并且有真实的公网用户正在依赖使用。我们不接受为刚创建且没有真实下载流量的 package 添加白名单
- [x] **Scope 要求**（如果申请添加 scope）：申请添加的 scope 必须已包含热门包（如周下载量超过 1 万）。我们不接受为刚创建且无热门包的 scope 添加白名单

### 📝 请提供以下信息

**添加的包/scope 名称：**

`hermes-web-ui`

**添加原因：**

`hermes-web-ui` 是 [Hermes Agent](https://github.com/NousResearch/hermes-agent)（Nous Research 出品的开源 AI Agent 框架）的官方 Web UI 组件，作为独立 npm 包发布，供用户通过 `npm install -g hermes-web-ui` 在本地启动 Hermes Agent 的 Web 管理界面。

从 v0.6.21 起，包内 bundle 了预编译的前端资源（Vue SPA + Node.js server + 桌面壳），unpacked size 从 ~78MB 增长到 ~90MB，超过了 npmmirror 单版本 80MB 的同步上限，导致 v0.6.21+ 的版本在 npmmirror 上无法同步（sync log 报错：`too many large versions, large package version size: 93144069, allow size: 83886080`）。

国内用户依赖 npmmirror 拉取 npm 包（无法直接访问 registry.npmjs.org），目前只能装到 v0.6.20，用不上后续版本的功能和安全修复。申请加入 `allowLargePackages` 白名单，让 npmmirror 能同步 0.6.21+ 的大版本。

**使用情况说明（如周下载量、依赖该包的项目等）：**

- npm 主页：https://www.npmjs.com/package/hermes-web-ui
- GitHub（关联项目）：https://github.com/NousResearch/hermes-agent
- 包类型：library（Node.js CLI + 内嵌 Web server）

### 📋 其他确认

- [x] 我已使用 CLI 工具添加（推荐），或已确保手动修改的 `package.json` 格式正确
- [x] 我理解此 PR 合并后会在 5 分钟内全网生效

---

感谢您为 unpkg 白名单做出贡献！🎉

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded package compatibility by allowing an additional package version in the approved list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->