### PR TITLE
feat: add `@volcengine` to allowLargeScopes

### DIFF
--- a/data/allowLargeScopes.json
+++ b/data/allowLargeScopes.json
@@ -30,5 +30,6 @@
   "@temporalio",
   "@tencent-ai",
   "@utoo",
+  "@volcengine",
   "@zed-industries"
 ]


### PR DESCRIPTION
## 添加白名单申请

请在提交此 Pull Request 之前，确认您已满足以下所有条件：

### 必须确认的条件

- [x] **遵循添加说明**：我已经按照 [README.md](https://github.com/cnpm/unpkg-white-list/blob/master/README.md) 中的说明正确添加了白名单条目
- [x] **非 GKD 订阅规则**：我添加的 scope **不是** GKD 广告屏蔽订阅规则相关的 scope（包含 `gkd`、`gkd-subscription`、`gkd_subscription` 等关键词的包将被直接关闭）
- [x] **包类型和使用情况**：该 scope 下的 package 是公开 npm CLI/native support packages，并且有真实的公网用户正在依赖使用。我们不接受为刚创建且没有真实下载流量的 scope 添加白名单
- [x] **Scope 要求**：本 PR 按维护者建议将 `@volcengine` 加入 `allowLargeScopes`，用于覆盖该 scope 下 veFaaS CLI 及平台二进制版本的大包同步

### 请提供以下信息

**添加的包/scope 名称：**

`@volcengine`

**添加原因：**

`@volcengine/vefaas-cli` 是火山引擎 veFaaS 的官方 npm CLI package，用于本地安装并运行 veFaaS 命令行工具。

该 CLI 通过 npm optional dependencies 分发不同平台的二进制包。当前 Windows x64 平台版本超过 npmmirror 默认 80MiB 同步上限，导致 npmmirror 无法同步最新版本。使用 npmmirror 作为 npm registry 的用户在执行 `npx @volcengine/vefaas-cli@latest install` 时会遇到 `ETARGET / No matching version found`。

当前 npmmirror 同步失败日志显示：

```text
Synced version 0.2.8-win32-x64 fail, too many large versions (4), large package version size: 110331698, allow size: 83886080
```

同步日志：https://registry.npmmirror.com/-/package/@volcengine/vefaas-cli/syncs/6a4b9601891b536169ebb4d2/log

因此按维护者建议将 `@volcengine` 加入 `allowLargeScopes`，允许该 scope 下的大体积平台二进制版本正常同步。

**使用情况说明（如周下载量、依赖该包的项目等）：**

- npm package: https://www.npmjs.com/package/@volcengine/vefaas-cli
- veFaaS console: https://console.volcengine.com/vefaas
- npm latest: `0.2.8`
- `@volcengine/vefaas-cli` npm downloads last week: 940（2026-06-29 至 2026-07-05）
- 包类型：公开 npm CLI package，面向 veFaaS 用户安装、升级和使用命令行工具

### 其他确认

- [x] 我已使用 CLI 工具添加（推荐），或已确保手动修改的 `package.json` 格式正确
- [x] 我理解此 PR 合并后会在 5 分钟内全网生效

### 验证

- `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the allowed large-scope list to include `@volcengine`, improving support for that scope in the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->