### PR TITLE
feat(allowLargePackages): add @spinejit/spine-codex

### DIFF
--- a/data/allowLargePackages.json
+++ b/data/allowLargePackages.json
@@ -44,6 +44,9 @@
   "@quasar/extras": {
     "version": "*"
   },
+  "@spinejit/spine-codex": {
+    "version": "*"
+  },
   "@teamolab/teamo-cli": {
     "version": "*"
   },


### PR DESCRIPTION
## 添加白名单申请

### ✅ 必须确认的条件

- [x] **遵循添加说明**：使用仓库提供的 CLI 将条目添加到
  `data/allowLargePackages.json`
- [x] **非 GKD 订阅规则**：该包与 GKD 订阅规则无关
- [ ] **包类型和使用情况**：这是一个公开的原生多平台 CLI，而不是
  JavaScript library。本申请仅解决 package tgz 大文件同步，不申请 unpkg
  静态文件托管。该仓库的 large-package 列表已有其他原生 CLI 包先例。
- [x] **Scope 要求**：不申请整个 scope，只申请单个 package

### 📝 信息

**添加的包名称：** `@spinejit/spine-codex`

**添加原因：**

npmmirror 同步任务因平台包超过默认 80 MiB 限制而停止。失败日志显示
`0.2.0-darwin-arm64` 的 unpacked size 为 `313359411` bytes，并提示将包加入
`cnpm/unpkg-white-list`。这是一个包含原生二进制的六平台 CLI，体积来自预期的
平台 payload。

**使用情况说明：**

- npm downloads API：2026-07-24 至 2026-07-30 共 1494 次下载
- 官方 npm `latest`：`0.2.1`
- 当前 npmmirror 因大包同步失败仍停留在旧元数据，导致 Linux ARM64 用户安装
  到不包含对应平台包的退休 alpha 版本

### 📋 其他确认

- [x] 已使用 `npm run add -- "--large-pkg=@spinejit/spine-codex"`
- [x] `npm test` 通过（10/10）
- [x] `npm run lint` 通过
- [x] 我理解合并发布后仍需重新触发 package sync 才能验证最终收敛


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added `@spinejit/spine-codex` to the list of packages permitted to exceed standard size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->