### PR TITLE
feat(allowLargeScopes): add `@nubjs` scope

### DIFF
--- a/data/allowLargeScopes.json
+++ b/data/allowLargeScopes.json
@@ -17,6 +17,7 @@
   "@mediapipe",
   "@next",
   "@node-llama-cpp",
+  "@nubjs",
   "@oh-my-pi",
   "@openai",
   "@oven",


### PR DESCRIPTION
`@nubjs/nub` ships 8 platform binary packages selected by npm `os`/`cpu` filters, same layout as @oven and @rolldown. Each exceeds the sync size limit:

```
Synced version 0.6.0 fail, too many large versions (4),
large package version size: 94782935, allow size: 83886080
```

All 8 are stuck at 0.0.31 (2026-06-10); npm is at 0.6.0. The small root package syncs, so installs resolve it and then fail:

```
no version of @nubjs/nub-darwin-x64 matches range 0.6.0
```

32,404 weekly downloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `@nubjs` to the approved allowlist for large scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->