### PR TITLE
feat: add @dptech-corp/bohr-cli to allowLargePackages

### DIFF
--- a/data/allowLargePackages.json
+++ b/data/allowLargePackages.json
@@ -14,6 +14,9 @@
   "@comate/zulu": {
     "version": "*"
   },
+  "@dptech-corp/bohr-cli": {
+    "version": "*"
+  },
   "@kilocode/cli": {
     "version": "*"
   },


### PR DESCRIPTION
## 添加白名单申请

### ✅ 必须确认的条件

- [x] **遵循添加说明**：我已经按照 README.md 中的说明正确添加了白名单条目
- [x] **非 GKD 订阅规则**：我添加的包不是 GKD 广告屏蔽订阅规则相关的包
- [x] **包类型和使用情况**：我添加的 package 是 CLI tool，并且有真实的公网用户正在依赖使用

### 📝 请提供以下信息

**添加的包名称：** `@dptech-corp/bohr-cli`

**添加原因：**

`@dptech-corp/bohr-cli` 是 [Bohrium 科学计算平台](https://bohrium.dp.tech) 的官方 CLI 工具，通过 npm 全局安装分发。该包内含 6 个平台预编译二进制（darwin-arm64/amd64, linux-arm64/amd64, windows-arm64/amd64），unpacked size ~195MB，超过 npmmirror 默认 80MB 同步限制，导致镜像站停留在旧版本无法同步。

**使用情况：**

- npm: https://www.npmjs.com/package/@dptech-corp/bohr-cli
- 安装方式：`npm install -g @dptech-corp/bohr-cli`
- 用途：Bohrium 平台用户通过此 CLI 提交计算任务、管理镜像和数据集
- 类似包：esbuild, turbo, @anthropic-ai/claude-code 等都是含多平台二进制的 CLI 工具

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `@dptech-corp/bohr-cli` to the list of packages permitted to exceed standard size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->