### PR TITLE
feat: add @kilocode to allowLargeScopes

### DIFF
--- a/data/allowLargePackages.json
+++ b/data/allowLargePackages.json
@@ -17,9 +17,6 @@
   "@dptech-corp/bohr-cli": {
     "version": "*"
   },
-  "@kilocode/cli": {
-    "version": "*"
-  },
   "@mapnik/core-darwin-arm64": {
     "version": "*"
   },

--- a/data/allowLargeScopes.json
+++ b/data/allowLargeScopes.json
@@ -13,6 +13,7 @@
   "@glyphix",
   "@google",
   "@iconify",
+  "@kilocode",
   "@lancedb",
   "@mediapipe",
   "@next",


### PR DESCRIPTION
## 添加白名单申请

请在提交此 Pull Request 之前，确认您已满足以下所有条件：

### ✅ 必须确认的条件

- [x] **遵循添加说明**：我已经按照 [README.md](https://github.com/cnpm/unpkg-white-list/blob/master/README.md) 中的说明正确添加了白名单条目
- [x] **非 GKD 订阅规则**：我添加的包 **不是** GKD 广告屏蔽订阅规则相关的包（包含 `gkd`、`gkd-subscription`、`gkd_subscription` 等关键词的包将被直接关闭）
- [x] **包类型和使用情况**：我添加的 package 是 npm CLI/native support packages，并且有真实的公网用户正在依赖使用。我们不接受为刚创建且没有真实下载流量的 package 添加白名单
- [x] **Scope 要求**（如果申请添加 scope）：申请添加的 scope 必须已包含热门包（@kilocode/cli 在上周npm下载量为72761）。我们不接受为刚创建且无热门包的 scope 添加白名单

### 📝 请提供以下信息

**添加的包/scope 名称：**

@kilocode

**添加原因：**

@kilocode/cli 是kilocode官方cli程序，其依赖的native包（如@kilocode/cli-linux-x64）体积过大，导致同步不及时。`❌ upstream error: Synced version 7.3.9 fail, too many large versions (4), large package version size: 181190231, allow size: 83886080`。详见<https://r.cnpmjs.org/-/package/@kilocode/cli-linux-x64/syncs/6a7c0f6099fdfc4b6ef7cc3e/log>。因此，仅添加@kilocode/cli 至白名单已不够用了，直接扩大至@kilocode。

**使用情况说明（如周下载量、依赖该包的项目等）：**

- npm package: https://www.npmjs.com/package/@kilocode/cli
- GitHub repository: https://github.com/Kilo-Org/kilocode
- npm downloads last week: 72761
- GitHub stars: 26827
包类型：公开 npm CLI package 及相关 native support packages，用于安装并运行 Kilocode terminal coding agent

### 📋 其他确认

- [x] 我已使用 CLI 工具添加（推荐），或已确保手动修改的 `package.json` 格式正确
- [x] 我理解此 PR 合并后会在 5 分钟内全网生效

### 验证

- npm test
- npm run lint
- printf '%s' 'feat: add @qwen-code to allowLargeScopes' | npx commitlint --verbose

---

感谢您为 unpkg 白名单做出贡献！🎉


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package size allowance settings.
  * Added the `@kilocode` scope to the list of permitted large scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->