### PR TITLE
feat: add `@amaster.ai/pi-computer-use` to allowLargePackages

### DIFF
--- a/data/allowLargePackages.json
+++ b/data/allowLargePackages.json
@@ -1,4 +1,7 @@
 {
+  "@amaster.ai/pi-computer-use": {
+    "version": "*"
+  },
   "@baidumap/mapv-three": {
     "version": "*"
   },


### PR DESCRIPTION
## What changed

- Add `@amaster.ai/pi-computer-use` to `allowLargePackages` for all versions.

## Why

npmmirror cannot sync the package because multiple published tarballs exceed the default 80 MiB limit. The sync currently stops with:

> Synced version 0.1.2-beta.13 fail, too many large versions (4), large package version size: 95569164, allow size: 83886080

This prevents newer versions such as `0.1.2-beta.59` from being available through `registry.npmmirror.com`.

## Impact

After the allowlist package is released, npmmirror can synchronize this specific package and downstream installs using the mirror can resolve its published versions.

## Checks

- `npm test`
- `npm run lint`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for the `@amaster.ai/pi-computer-use` package without package-size restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->