### PR TITLE
feat: add @deveco/deveco-code packages to allowLargePackages

### DIFF
--- a/data/allowLargePackages.json
+++ b/data/allowLargePackages.json
@@ -17,6 +17,18 @@
   "@comate/zulu": {
     "version": "*"
   },
+  "@deveco/deveco-code-darwin-arm64": {
+    "version": "*"
+  },
+  "@deveco/deveco-code-darwin-x64": {
+    "version": "*"
+  },
+  "@deveco/deveco-code-windows-x64": {
+    "version": "*"
+  },
+  "@deveco/deveco-code-windows-x64-baseline": {
+    "version": "*"
+  },
   "@dptech-corp/bohr-cli": {
     "version": "*"
   },


### PR DESCRIPTION
添加白名单申请
请在提交此 Pull Request 之前，确认您已满足以下所有条件：

## ✅ 必须确认的条件

- [x] **遵循添加说明**：我已经按照 README.md 中的说明正确添加了白名单条目（按字母序插入 `data/allowLargePackages.json`，仅编辑 data 目录 JSON，未手改 package.json）
- [x] **非 GKD 订阅规则**：我添加的包不是 GKD 广告屏蔽订阅规则相关的包
- [x] **包类型和使用情况**：这些 package 是 `@deveco/deveco-code` 的平台二进制 optionalDependencies（随主包 `npm install` 自动按平台拉取），有真实公网用户依赖使用（见下方周下载量），非刚创建且无下载流量的包
- [ ] **Scope 要求**：N/A —— 本 PR 添加的是具体 package，未添加 scope

## 📝 请提供以下信息

**添加的包/scope 名称：**
4 个 package：
- `@deveco/deveco-code-darwin-arm64`
- `@deveco/deveco-code-darwin-x64`
- `@deveco/deveco-code-windows-x64`
- `@deveco/deveco-code-windows-x64-baseline`

**添加原因：**
`@deveco/deveco-code` 的 4 个平台二进制包每个版本是一个完整 IDE 构建（unpackedSize 约 132–175MB），超过 80MiB 大版本上限。每次发布新版本，npmmirror 上游同步（r.cnpmjs.org）报 `too many large versions (4), large package version size: 177555724, allow size: 83886080` 并 give up。本 PR 将这 4 个平台包纳入 large package 白名单，使超大 tgz 可按策略同步。

**问题概述**
`@deveco/deveco-code-windows-x64` / `@deveco/deveco-code-windows-x64-baseline` / `@deveco/deveco-code-darwin-arm64` / `@deveco/deveco-code-darwin-x64` 命中大小阈值，当前策略拒绝上游同步（npmmirror 虽会回退直连 npmjs.org 兜底，但上游链路 give up）。

**变更内容**
在 `data/allowLargePackages.json` 中按字母序新增 4 个条目（version 为 `*`）：
```json
  "@deveco/deveco-code-darwin-arm64": {
    "version": "*"
  },
  "@deveco/deveco-code-darwin-x64": {
    "version": "*"
  },
  "@deveco/deveco-code-windows-x64": {
    "version": "*"
  },
  "@deveco/deveco-code-windows-x64-baseline": {
    "version": "*"
  },
```

**影响范围**
仅影响 large package 同步准入策略，不改动常规白名单或业务逻辑。与现有白名单中 `opencode-*`、`oh-my-openagent-*`、`makecoder-bin-*` 多平台二进制变体的先例一致。

**使用情况说明（如周下载量、依赖该包的项目等）：**
`@deveco/deveco-code` 为 DevEco Code（华为 HarmonyOS 开发工具链）分发入口，4 个平台包为其 optionalDependencies，随主包按平台自动安装。最近一周下载量（npm registry 统计）：
- `@deveco/deveco-code`：1512 / 周
- `@deveco/deveco-code-windows-x64`：1111 / 周
- `@deveco/deveco-code-windows-x64-baseline`：1188 / 周
- `@deveco/deveco-code-darwin-arm64`：590 / 周
- `@deveco/deveco-code-darwin-x64`：380 / 周

平台包合计约 3269 / 周，有真实公网下载流量。

## 📋 其他确认

- [x] 我已使用 CLI 工具添加（推荐），或已确保手动修改的 package.json 格式正确（已按 CLI 输出等价的字段顺序与格式手工插入，JSON 合法，`npm test` 10/10 通过，`npm run lint` 通过）
- [x] 我理解此 PR 合并后会在 5 分钟内全网生效
