### PR TITLE
feat: add `@guandata/guanvis` to allowLargePackages

### DIFF
--- a/data/allowLargePackages.json
+++ b/data/allowLargePackages.json
@@ -20,6 +20,9 @@
   "@dptech-corp/bohr-cli": {
     "version": "*"
   },
+  "@guandata/guanvis": {
+    "version": ">=0.1.32"
+  },
   "@mapnik/core-darwin-arm64": {
     "version": "*"
   },

--- a/data/allowLargePackages.json
+++ b/data/allowLargePackages.json
@@ -21,7 +21,7 @@
     "version": "*"
   },
   "@guandata/guanvis": {
-    "version": ">=0.1.32"
+    "version": "*"
   },
   "@mapnik/core-darwin-arm64": {
     "version": "*"


### PR DESCRIPTION
## 添加白名单申请

请在提交此 Pull Request 之前，确认您已满足以下所有条件：

### ✅ 必须确认的条件

- [x] **遵循添加说明**：我已经按照 [README.md](https://github.com/cnpm/unpkg-white-list/blob/master/README.md) 中的说明，通过仓库 CLI 将条目加入 `data/allowLargePackages.json`
- [x] **非 GKD 订阅规则**：该包不是 GKD 广告屏蔽订阅规则相关的包
- [x] **包类型和使用情况**：该包是公开发布的观远 BI 可视化构建 CLI / Skill runtime，通过 npm 安装使用，不用于通过 CDN 分发应用内容；存在真实公网用户和下载量
- [x] **Scope 要求**：本次仅申请指定 package，不申请整个 scope

### 📝 请提供以下信息

**添加的包/scope 名称：**

`@guandata/guanvis >=0.1.32`

**添加原因：**

从 `0.1.32` 开始，包的 `dist.unpackedSize` 超过 npmmirror 的 80 MiB 限制。当前 `0.1.43` 为 124,315,813 bytes，强制同步因此停留在 `0.1.31`。

失败日志：https://registry.npmmirror.com/-/package/@guandata%2Fguanvis/syncs/6a97940747db24a226f0570a/log

**使用情况说明（如周下载量、依赖该包的项目等）：**

该包用于观远 BI 可视化页面和图表的构建、校验及发布。npm 官方下载统计在 2026-08-23 至 2026-08-29 为 1,088 次。

### 📋 其他确认

- [x] 我已使用 CLI 工具添加，并运行 `npm test`（10 项通过）、`npm run lint` 和 `git diff --check`
- [x] 我理解此 PR 合并后会在 5 分钟内全网生效


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package handling to permit larger package sizes for `@guandata/guanvis` packages across all versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->