### PR TITLE
feat: add phaser to allowLargePackages

### DIFF
--- a/data/allowLargePackages.json
+++ b/data/allowLargePackages.json
@@ -248,6 +248,9 @@
   "opencode-windows-x64-baseline": {
     "version": "*"
   },
+  "phaser": {
+    "version": "*"
+  },
   "plotly.js": {
     "version": "*"
   },


### PR DESCRIPTION
## 添加白名单申请

### ✅ 必须确认的条件

- [x] **遵循添加说明**：已按照 README，通过仓库 CLI 将 `phaser` 加入 `data/allowLargePackages.json`
- [x] **非 GKD 订阅规则**：该包不是 GKD 广告屏蔽订阅规则相关的包
- [x] **包类型和使用情况**：Phaser 是开源 HTML5 游戏开发框架，属于 library，有真实公网用户依赖使用
- [x] **Scope 要求**：本次仅申请指定 package，不申请整个 scope

### 📝 请提供以下信息

**添加的包/scope 名称：**

`phaser`，版本范围为 `*`，添加至 `allowLargePackages`。

**添加原因：**

npmmirror 同步 `phaser` 时，上游同步任务因超大版本数量及包体积限制失败。日志显示，`4.0.0-rc.6` 的包体积为 129,185,889 bytes，超过默认的 83,886,080 bytes（80 MiB）限制：

> Synced version 4.0.0-rc.6 fail, too many large versions (4), large package version size: 129185889, allow size: 83886080

虽然外层同步最终显示成功，但上游明确报告失败，本次同步新增版本数为 0。申请加入超大包同步白名单，以允许相关版本正常同步。

同步日志：
https://registry.npmmirror.com/-/package/phaser/syncs/6a9ccc512792831113dc4bc0/log

上游失败日志：
https://r.cnpmjs.org/-/package/phaser/syncs/6a9ccc5244d44de35094146a/log

**使用情况说明（如周下载量、依赖该包的项目等）：**

Phaser 是用于开发 Web 2D 游戏的开源框架，通过 npm 向游戏开发项目提供运行库，具有真实的开发者用户和应用场景。

- 项目官网：https://phaser.io/
- npm 包：https://www.npmjs.com/package/phaser
- 源码仓库：https://github.com/phaserjs/phaser

### 📋 其他确认

- [x] 已使用 CLI 工具添加：`npm run add -- "--large-pkg=phaser"`
- [x] 已运行 `npm test`（10 项全部通过）、`npm run lint` 和 `git diff --check`
- [x] 我理解此 PR 合并后会在 5 分钟内全网生效

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Phaser to the list of supported large packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->